### PR TITLE
[feat] : 비슷한 온도 옷차림 추천 API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3370,7 +3370,6 @@
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
-      "license": "MIT",
       "bin": {
         "uuid": "dist/esm/bin/uuid"
       }

--- a/prisma/migrations/20250721013629_add_feels_like_temp_to_outfit/migration.sql
+++ b/prisma/migrations/20250721013629_add_feels_like_temp_to_outfit/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE `outfit` ADD COLUMN `feelsLikeTemp` DOUBLE NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -79,6 +79,7 @@ model Outfit {
   locationId     Int
   date           DateTime
   weatherTempAvg Float?
+  feelsLikeTemp  Float?
   mainImage      String?
   memo           String?
   outfitItems    OutfitItem[]

--- a/src/modules/home/home.controller.js
+++ b/src/modules/home/home.controller.js
@@ -1,6 +1,7 @@
 import { getCurrentDate } from './home.service.js';
 import { OkSuccess } from '../../utils/success.js';
 import { InvalidInputError } from '../../utils/error.js';
+import { getSimilarTemperatureOutfits } from '../outfit/outfit.service.js';
 
 export const getCurrentDateController = (req, res, next) => {
   try {
@@ -12,5 +13,16 @@ export const getCurrentDateController = (req, res, next) => {
   } catch (err) {
     // 예외 발생 시 에러 미들웨어로 전달
     next(new InvalidInputError("현재 날짜 조회 실패", err));
+  }
+};
+
+export const getSimilarWeatherOutfitsController = async (req, res, next) => {
+  try {
+    const userId = req.user.userId;
+    const result = await getSimilarTemperatureOutfits(userId);
+    
+    res.status(200).json(new OkSuccess(result, "비슷한 날씨 옷차림 조회 성공"));
+  } catch (err) {
+    next(err);
   }
 };

--- a/src/modules/outfit/outfit.controller.js
+++ b/src/modules/outfit/outfit.controller.js
@@ -1,7 +1,8 @@
 import { 
   createOutfit, 
   getFeelsLikeTempOptions, 
-  getAllTags 
+  getAllTags,
+  testLocationConnection
 } from './outfit.service.js';
 import { OkSuccess, CreatedSuccess } from '../../utils/success.js';
 import { InvalidInputError } from '../../utils/error.js';
@@ -47,5 +48,21 @@ export const createOutfitController = async (req, res, next) => {
     res.status(201).json(new CreatedSuccess(outfit, "아웃핏 등록 성공"));
   } catch (err) {
     next(new InvalidInputError("아웃핏 등록 실패", err.message));
+  }
+};
+
+// ✅ 위치 연동 테스트 컨트롤러  
+export const testLocationController = async (req, res, next) => {
+  try {
+    const userId = req.user.userId;
+    const result = await testLocationConnection(userId);
+    
+    if (result.success) {
+      res.status(200).json(new OkSuccess(result, "위치 정보 연동 테스트 성공"));
+    } else {
+      res.status(200).json(new OkSuccess(result, "위치 정보 연동 테스트 완료 (일부 오류 발생)"));
+    }
+  } catch (err) {
+    next(err);
   }
 };

--- a/src/modules/outfit/outfit.controller.js
+++ b/src/modules/outfit/outfit.controller.js
@@ -1,8 +1,7 @@
 import { 
   createOutfit, 
   getFeelsLikeTempOptions, 
-  getAllTags,
-  testLocationConnection
+  getAllTags
 } from './outfit.service.js';
 import { OkSuccess, CreatedSuccess } from '../../utils/success.js';
 import { InvalidInputError } from '../../utils/error.js';
@@ -29,7 +28,7 @@ export const createOutfitController = async (req, res, next) => {
   try {
     const { date, mainImage } = req.body;
     const { moodTags = [], purposeTags = [] } = req.body;
-    const userId = req.user.userId; // JWT에서 사용자 ID 추출
+    const userId = req.user.userId || req.user.id; // JWT에서 사용자 ID 추출
     
     
     // 필수 필드 검증
@@ -43,7 +42,7 @@ export const createOutfitController = async (req, res, next) => {
       throw new InvalidInputError("태그는 최대 3개까지만 선택할 수 있습니다.");
     }
     
-    const outfit = await createOutfit({ ...req.body, userId });
+    const outfit = await createOutfit({ ...req.body, userId: userId });
      
     res.status(201).json(new CreatedSuccess(outfit, "아웃핏 등록 성공"));
   } catch (err) {
@@ -51,17 +50,14 @@ export const createOutfitController = async (req, res, next) => {
   }
 };
 
-// ✅ 위치 연동 테스트 컨트롤러  
-export const testLocationController = async (req, res, next) => {
+//비슷한 온도 Outfit 조회 컨트롤러
+export const getSimilarOutfitsController = async (req, res, next) => {
   try {
     const userId = req.user.userId;
-    const result = await testLocationConnection(userId);
+    const tempRange = req.query.range ? parseInt(req.query.range) : 2;
     
-    if (result.success) {
-      res.status(200).json(new OkSuccess(result, "위치 정보 연동 테스트 성공"));
-    } else {
-      res.status(200).json(new OkSuccess(result, "위치 정보 연동 테스트 완료 (일부 오류 발생)"));
-    }
+    const result = await getSimilarTemperatureOutfits(userId, tempRange);
+    res.status(200).json(new OkSuccess(result, "비슷한 온도의 옷차림 기록 조회 성공"));
   } catch (err) {
     next(err);
   }

--- a/src/modules/outfit/outfit.service.js
+++ b/src/modules/outfit/outfit.service.js
@@ -142,11 +142,6 @@ export async function createOutfit(outfitData) {
     purposeTags = []
   } = outfitData;
   
-   console.log('🔍 추출된 userId:', userId);
-  
-  if (!userId) {
-    throw new Error('userId가 제공되지 않았습니다.');
-  }
 
   // 1. 위치 정보 가져오기
   const location = await getCurrentLocation(userId);

--- a/src/routes/home.route.js
+++ b/src/routes/home.route.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getCurrentDateController } from '../modules/home/home.controller.js';
+import { getCurrentDateController, getSimilarWeatherOutfitsController } from '../modules/home/home.controller.js';
 import { getCurrentWeather } from '../modules/weather/weather.controller.js';
 import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
@@ -8,5 +8,6 @@ const router = express.Router();
 //router.get('/common/date', authenticateJWT, getCurrentDateController);
 router.get('/common/date', getCurrentDateController);
 router.get('/weather/current', authenticateJWT, getCurrentWeather);
+router.get('/home/similar-weather', authenticateJWT, getSimilarWeatherOutfitsController);
 
 export default router;

--- a/src/routes/home.route.js
+++ b/src/routes/home.route.js
@@ -1,7 +1,7 @@
 import express from 'express';
 import { getCurrentDateController } from '../modules/home/home.controller.js';
 import { getCurrentWeather } from '../modules/weather/weather.controller.js';
-import authenticateJWT from '../middlewares/auth.middleware.js';
+import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
 const router = express.Router();
 

--- a/src/routes/outfit.route.js
+++ b/src/routes/outfit.route.js
@@ -2,7 +2,8 @@ import express from 'express';
 import { 
   createOutfitController,
   getFeelsLikeTempController,
-  getTagsController
+  getTagsController,
+  testLocationController
 } from '../modules/outfit/outfit.controller.js';
 import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
@@ -15,5 +16,6 @@ router.get('/tags/options', getTagsController);
 // 인증 필요
 router.post('/outfits', authenticateJWT, createOutfitController);
 
+router.get('/outfit/test-location', authenticateJWT, testLocationController);
 
 export default router;

--- a/src/routes/outfit.route.js
+++ b/src/routes/outfit.route.js
@@ -2,8 +2,7 @@ import express from 'express';
 import { 
   createOutfitController,
   getFeelsLikeTempController,
-  getTagsController,
-  testLocationController
+  getTagsController
 } from '../modules/outfit/outfit.controller.js';
 import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
@@ -15,7 +14,5 @@ router.get('/tags/options', getTagsController);
 
 // 인증 필요
 router.post('/outfits', authenticateJWT, createOutfitController);
-
-router.get('/outfit/test-location', authenticateJWT, testLocationController);
 
 export default router;


### PR DESCRIPTION
**📋 API 엔드포인트**
GET /home/similar-weather - 현재 날씨와 비슷한 온도의 과거 옷차림 추천

**🌤️ 비슷한 온도 기반 옷차림 추천 시스템**
온도 범위 매칭
현재 날씨 온도 기준 ±2도 범위 내의 과거 옷차림 기록 조회

예: 현재 31°C → 29°C~33°C 범위의 과거 옷차림 추천

**추천 데이터 구성**
- 체감온도: 사용자가 실제 입력한 체감온도 (1-5단계)
- 옷차림 이미지: 과거 등록한 outfit 사진
- 최대 10개 제한: 성능 최적화를 위한 데이터 제한

**💾 데이터베이스 및 API 연동**
다른 API 개발 전 임시로 넣어두었던 데이터 및 API 실제 연동
온도, 사용자 아이디, 위치 등 실제 데이터 활용

**💾 데이터베이스 수정**
feelsLikeTemp 컬럼을 outfit 테이블에 추가