### PR TITLE
[feat] 내일 날씨 API

### DIFF
--- a/src/modules/weather/weather.controller.js
+++ b/src/modules/weather/weather.controller.js
@@ -12,3 +12,13 @@ export const getCurrentWeather = async (req, res, next) => {
     next(err);
   }
 };
+
+export const getTomorrowWeather = async (req, res, next) => {
+  try {
+    const userId = req.user.userId;
+    const result = await weatherService.getTomorrowWeatherByUserId(userId);
+    res.status(200).json(new OkSuccess(result, "내일 날씨 조회 성공"));
+  } catch (err) {
+    next(err);
+  }
+};

--- a/src/modules/weather/weather.service.js
+++ b/src/modules/weather/weather.service.js
@@ -58,64 +58,8 @@ const mapWeatherStatusWithPriority = (weatherArray) => {
   return getDetailedStatus(selectedWeather);
 };
 
-// OpenWeather API 호출
-const fetchWeatherData = async (latitude, longitude) => {
-  const apiKey = process.env.OPENWEATHER_API_KEY;
-  
-  if (!apiKey) {
-    throw new WeatherApiError('OpenWeather API 키가 설정되지 않았습니다.');
-  }
-
-  try {
-    const [currentResponse, forecastResponse] = await Promise.all([
-      axios.get(`https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&appid=${apiKey}&units=metric&lang=kr`),
-      axios.get(`https://api.openweathermap.org/data/2.5/forecast?lat=${latitude}&lon=${longitude}&appid=${apiKey}&units=metric&lang=kr`)
-    ]);
-
-    const current = currentResponse.data;
-    const forecast = forecastResponse.data;
-    
-    // 오늘 최고/최저 온도 계산
-    const today = new Date().toDateString();
-    const todayForecasts = forecast.list.filter(item => {
-      return new Date(item.dt * 1000).toDateString() === today;
-    });
-
-    let tempMin = current.main.temp;
-    let tempMax = current.main.temp;
-    
-    if (todayForecasts.length > 0) {
-      tempMin = Math.min(...todayForecasts.map(f => f.main.temp_min));
-      tempMax = Math.max(...todayForecasts.map(f => f.main.temp_max));
-    }
-
-    return {
-      tempAvg: Math.round(current.main.temp * 10) / 10,
-      tempMin: Math.round(tempMin * 10) / 10,
-      tempMax: Math.round(tempMax * 10) / 10,
-      feelsLike: Math.round(current.main.feels_like * 10) / 10,
-      precipitation: Math.round(forecast.list[0].pop * 100),
-      status: mapWeatherStatusWithPriority(current.weather) // ✅ 새로운 매핑 함수 사용
-    };
-  } catch (error) {
-    if (error instanceof WeatherApiError) throw error;
-
-    if (error.response?.status === 401) {
-      throw new WeatherApiError('OpenWeather API 키가 유효하지 않습니다.');
-    }
-    if (error.response?.status === 404) {
-      throw new WeatherApiError('해당 위치의 날씨 정보를 찾을 수 없습니다.');
-    }
-    if (error.response?.status === 429) {
-      throw new WeatherApiError('날씨 API 호출 한도를 초과했습니다.');
-    }
-    
-    throw new WeatherApiError('날씨 서비스 연결에 실패했습니다.');
-  }
-};
-
-// 사용자 ID로 날씨 조회
-export const getCurrentWeatherByUserId = async (userId) => {
+// ✅ 핵심: 공통 함수 하나로 현재/내일 처리
+const getWeatherByDate = async (userId, isToday = true) => {
   const userWithLocation = await findUserWithLocation(userId);
   
   if (!userWithLocation || !userWithLocation.location) {
@@ -123,12 +67,11 @@ export const getCurrentWeatherByUserId = async (userId) => {
   }
 
   const location = userWithLocation.location;
-
   if (!location.latitude || !location.longitude) {
     throw new UserLocationNotFoundError('위치 좌표 정보가 없습니다. 위치를 다시 설정해주세요.');
   }
 
-  const weatherData = await fetchWeatherData(location.latitude, location.longitude);
+  const weatherData = await fetchWeatherData(location.latitude, location.longitude, isToday);
 
   return {
     location: {
@@ -138,4 +81,112 @@ export const getCurrentWeatherByUserId = async (userId) => {
     },
     weather: weatherData
   };
+};
+
+// OpenWeather API 호출
+const fetchWeatherData = async (latitude, longitude, isToday) => {
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  
+  if (!apiKey) {
+    throw new WeatherApiError('OpenWeather API 키가 설정되지 않았습니다.');
+  }
+
+  try {
+    // 오늘날씨
+    if(isToday){
+    const [currentResponse, forecastResponse] = await Promise.all([
+      axios.get(`https://api.openweathermap.org/data/2.5/weather?lat=${latitude}&lon=${longitude}&appid=${apiKey}&units=metric&lang=kr`),
+      axios.get(`https://api.openweathermap.org/data/2.5/forecast?lat=${latitude}&lon=${longitude}&appid=${apiKey}&units=metric&lang=kr`)
+    ]);
+
+    return buildCurrentWeatherResponse(currentResponse.data, forecastResponse.data.list);
+    }
+     else {
+      // 내일 날씨 
+      const forecastResponse = await axios.get(
+        `https://api.openweathermap.org/data/2.5/forecast?lat=${latitude}&lon=${longitude}&appid=${apiKey}&units=metric&lang=kr`
+      );
+
+      return buildTomorrowWeatherResponse(forecastResponse.data.list);
+    }
+  } catch (error) {
+    if (error instanceof WeatherApiError) throw error;
+    if (error.response?.status === 401) throw new WeatherApiError('OpenWeather API 키가 유효하지 않습니다.');
+    if (error.response?.status === 404) throw new WeatherApiError('해당 위치의 날씨 정보를 찾을 수 없습니다.');
+    throw new WeatherApiError('날씨 서비스 연결에 실패했습니다.');
+  }
+ };
+
+// 오늘 날씨 응답 구성
+const buildCurrentWeatherResponse = (current, forecastList) => {
+  const today = new Date().toDateString();
+  const todayForecasts = forecastList.filter(item => 
+    new Date(item.dt * 1000).toDateString() === today
+  );
+
+  const todayMinTemp = todayForecasts.length > 0 
+    ? Math.min(...todayForecasts.map(f => f.main.temp_min))
+    : current.main.temp_min;
+  
+  const todayMaxTemp = todayForecasts.length > 0
+    ? Math.max(...todayForecasts.map(f => f.main.temp_max))
+    : current.main.temp_max;
+
+  const maxPrecipitation = todayForecasts.length > 0
+    ? Math.max(...todayForecasts.map(f => f.pop * 100))
+    : 0;
+
+  return {
+    tempAvg: Math.round(current.main.temp),
+    tempMin: Math.round(todayMinTemp * 10) / 10,
+    tempMax: Math.round(todayMaxTemp * 10) / 10,
+    feelsLike: Math.round(current.main.feels_like * 10) / 10,
+    precipitation: Math.round(maxPrecipitation),
+    status: mapWeatherStatusWithPriority(current.weather)
+  };
+};
+
+// 내일 날씨 응답 구성
+const buildTomorrowWeatherResponse = (forecastList) => {
+  const tomorrow = new Date();
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const tomorrowDateString = tomorrow.toDateString();
+  
+  const tomorrowForecasts = forecastList.filter(item => 
+    new Date(item.dt * 1000).toDateString() === tomorrowDateString
+  );
+
+  if (tomorrowForecasts.length === 0) {
+    throw new WeatherApiError('내일 날씨 정보를 찾을 수 없습니다.');
+  }
+
+  const tempMin = Math.min(...tomorrowForecasts.map(f => f.main.temp_min));
+  const tempMax = Math.max(...tomorrowForecasts.map(f => f.main.temp_max));
+  const tempAvg = tomorrowForecasts.reduce((sum, f) => sum + f.main.temp, 0) / tomorrowForecasts.length;
+  
+  // 낮 시간대 대표 데이터
+  const noonForecast = tomorrowForecasts.find(f => {
+    const hour = new Date(f.dt * 1000).getHours();
+    return hour >= 11 && hour <= 14;
+  }) || tomorrowForecasts[0];
+
+  const maxPrecipitation = Math.max(...tomorrowForecasts.map(f => f.pop * 100));
+
+  return {
+    tempAvg: Math.round(tempAvg * 10) / 10,
+    tempMin: Math.round(tempMin * 10) / 10,
+    tempMax: Math.round(tempMax * 10) / 10,
+    feelsLike: Math.round(noonForecast.main.feels_like * 10) / 10,
+    precipitation: Math.round(maxPrecipitation),
+    status: mapWeatherStatusWithPriority(noonForecast.weather)
+  };
+};
+
+// ✅ 간단해진 export 함수들
+export const getCurrentWeatherByUserId = async (userId) => {
+  return await getWeatherByDate(userId, true);   // true = 오늘
+};
+
+export const getTomorrowWeatherByUserId = async (userId) => {
+  return await getWeatherByDate(userId, false);  // false = 내일
 };

--- a/src/routes/home.route.js
+++ b/src/routes/home.route.js
@@ -1,6 +1,6 @@
 import express from 'express';
 import { getCurrentDateController, getSimilarWeatherOutfitsController } from '../modules/home/home.controller.js';
-import { getCurrentWeather } from '../modules/weather/weather.controller.js';
+import { getCurrentWeather, getTomorrowWeather} from '../modules/weather/weather.controller.js';
 import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
 const router = express.Router();
@@ -8,6 +8,7 @@ const router = express.Router();
 //router.get('/common/date', authenticateJWT, getCurrentDateController);
 router.get('/common/date', getCurrentDateController);
 router.get('/weather/current', authenticateJWT, getCurrentWeather);
+router.get('/weather/tomorrow', authenticateJWT, getTomorrowWeather);
 router.get('/home/similar-weather', authenticateJWT, getSimilarWeatherOutfitsController);
 
 export default router;


### PR DESCRIPTION
**📋 API 엔드포인트**
GET /weather/tomorrow - 사용자 설정 위치 기반 내일 날씨 조회

**🌤️ 내일 날씨 조회 시스템**
날씨 데이터 처리
OpenWeather 5일 예보 API 활용으로 내일 날씨 데이터 추출
시간대별 데이터 통합: 내일 하루 전체(00:00~21:00, 3시간 간격)의 예보 데이터 활용
평균 온도 계산: 내일 하루 8개 시점의 실제 평균 온도 산출

응답 데이터 구성

- tempAvg: 내일 하루 전체의 계산된 평균 온도
- tempMin/tempMax: 내일 예상 최저/최고 온도
- feelsLike: 낮 시간대(11-14시) 기준 체감온도
- precipitation: 내일 전체 중 최대 강수 확률
- status: 낮 시간대 기준 대표 날씨 상태

**🔧 코드 최적화 및 리팩토링**
- 중복 코드 제거
공통 함수 통합: getWeatherByDate(userId, isToday) 하나로 현재/내일 날씨 처리