### PR TITLE
[feat] 사용자의 7일간 outfit 조회 API

### DIFF
--- a/src/modules/home/home.controller.js
+++ b/src/modules/home/home.controller.js
@@ -1,7 +1,6 @@
-import { getCurrentDate } from './home.service.js';
+import { getCurrentDate, getHomeRecentOutfits, getHomeSimilarOutfits} from './home.service.js';
 import { OkSuccess } from '../../utils/success.js';
 import { InvalidInputError } from '../../utils/error.js';
-import { getSimilarTemperatureOutfits } from '../outfit/outfit.service.js';
 
 export const getCurrentDateController = (req, res, next) => {
   try {
@@ -19,9 +18,19 @@ export const getCurrentDateController = (req, res, next) => {
 export const getSimilarWeatherOutfitsController = async (req, res, next) => {
   try {
     const userId = req.user.userId;
-    const result = await getSimilarTemperatureOutfits(userId);
-    
+    const result = await getHomeSimilarOutfits(userId);
     res.status(200).json(new OkSuccess(result, "비슷한 날씨 옷차림 조회 성공"));
+  } catch (err) {
+    next(err);
+  }
+};
+
+/** GET /home/recent-outfits */
+export const getRecentOutfitsController = async (req, res, next) => {
+  try {
+    const userId = req.user.userId;
+    const result = await getHomeRecentOutfits(userId);
+    res.status(200).json(new OkSuccess(result, '지난 7일간 코디 조회 성공'));
   } catch (err) {
     next(err);
   }

--- a/src/modules/home/home.service.js
+++ b/src/modules/home/home.service.js
@@ -1,7 +1,22 @@
+import {
+  getSimilarTemperatureOutfits,
+  getUserRecent7DaysOutfits
+} from '../outfit/outfit.service.js';
+
 export function getCurrentDate() {
   const now = new Date();
   const yyyy = now.getFullYear();
   const mm = String(now.getMonth() + 1).padStart(2, '0');
   const dd = String(now.getDate()).padStart(2, '0');
   return `${yyyy}-${mm}-${dd}`;
+}
+
+/** 홈: 현재 온도 기준 ±2℃ 비슷한 아웃핏 */
+export async function getHomeSimilarOutfits(userId) {
+  return await getSimilarTemperatureOutfits(userId);
+}
+
+/** 홈: 지난 7일간 아웃핏 */
+export async function getHomeRecentOutfits(userId) {
+  return await getUserRecent7DaysOutfits(userId);
 }

--- a/src/modules/outfit/outfit.service.js
+++ b/src/modules/outfit/outfit.service.js
@@ -180,3 +180,37 @@ export async function createOutfit(outfitData) {
     purposeTags
   };
 }
+
+export async function getUserRecent7DaysOutfits(userId) {
+  // 7일 전 시작일과 오늘 종료일 계산
+  const to   = new Date(); to.setHours(23,59,59,999);
+  const from = new Date(); from.setDate(from.getDate() - 6);
+                       from.setHours(0,0,0,0);
+
+  // DB에서 조회
+  const outfits = await prisma.outfit.findMany({
+    where: {
+      userId,
+      date: { gte: from, lte: to }
+    },
+    select: {
+      date: true,
+      mainImage: true
+    },
+    orderBy: { date: 'desc' }
+  });
+
+  // 사용자 정보
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { nickname: true }
+  });
+
+  return {
+    userName: user.nickname,
+    outfits: outfits.map(o => ({
+      date: o.date.toISOString().split('T')[0],  // YYYY-MM-DD
+      image: o.mainImage
+    }))
+  };
+}

--- a/src/routes/home.route.js
+++ b/src/routes/home.route.js
@@ -1,5 +1,5 @@
 import express from 'express';
-import { getCurrentDateController, getSimilarWeatherOutfitsController } from '../modules/home/home.controller.js';
+import { getCurrentDateController, getSimilarWeatherOutfitsController, getRecentOutfitsController } from '../modules/home/home.controller.js';
 import { getCurrentWeather } from '../modules/weather/weather.controller.js';
 import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
@@ -9,5 +9,6 @@ const router = express.Router();
 router.get('/common/date', getCurrentDateController);
 router.get('/weather/current', authenticateJWT, getCurrentWeather);
 router.get('/home/similar-weather', authenticateJWT, getSimilarWeatherOutfitsController);
+router.get('/outfits/recent', authenticateJWT, getRecentOutfitsController); 
 
 export default router;


### PR DESCRIPTION
**📋 API 엔드포인트**
GET /outfits/recent - 사용자의 지난 7일간 코디 기록 조회

**🗓️ 최근 7일간 아웃핏 조회 시스템**
기간 범위 매칭
조회 기간: 오늘 포함 최근 7일간 (00:00:00 ~ 23:59:59)
예시: 2025-07-21 기준 → 2025-07-15 ~ 2025-07-21 범위 조회

응답 데이터 구성
- 사용자 이름: 사용자 닉네임 정보
- 코디 날짜: 아웃핏 등록 날짜 (YYYY-MM-DD 형식)
- 아웃핏 이미지: 등록된 메인 이미지 파일명
- 최신순 정렬: 가장 최근 등록된 코디부터 반환


**💾 데이터베이스 및 API 연동**
Home 모듈과 Outfit 모듈 책임 분리
- Home 모듈: 홈 화면 전용 UI 데이터 조립 로직
- Outfit 모듈: 순수 DB 조회 및 비즈니스 로직 제공
- 실제 사용자 ID, 날짜 범위 필터링 등 실제 데이터 활용