### PR TITLE
[feat] delete outfit upload

### DIFF
--- a/src/middlewares/error.middleware.js
+++ b/src/middlewares/error.middleware.js
@@ -1,6 +1,8 @@
 export const errorHandler = (err, req, res, next) => {
   if (err instanceof Error && err.errorCode && err.statusCode) {
-    res.status(err.statusCode).json({
+    let statusCode = typeof err.statusCode === 'number' ? err.statusCode : parseInt(err.statusCode, 10);
+    if (isNaN(statusCode)) statusCode = 500;
+    res.status(statusCode).json({
       resultType: "FAIL",
       error: {
         errorCode: err.errorCode,

--- a/src/modules/community/community.controller.js
+++ b/src/modules/community/community.controller.js
@@ -56,3 +56,16 @@ export const publishTodayOutfitController = async (req, res, next) => {
   }
 };
 
+export const deletePublishedOutfitController = async (req, res, next) => {
+  try {
+    const userId = req.user.userId;
+    const outfitId = parseInt(req.params.outfitId);
+
+    const result = await communityService.deletePublishedOutfit(userId, outfitId);
+
+    return res.status(200).json(new OkSuccess(result, '아웃핏 게시글이 삭제되었습니다.'));
+  } catch (err) {
+    next(err);
+  }
+};
+

--- a/src/routes/community.route.js
+++ b/src/routes/community.route.js
@@ -3,7 +3,8 @@ import {
     toggleOutfitLikeController,
     getPublishedOutfitsByOutfitTagsController,
     getTodayOutfitStatusController,
-    publishTodayOutfitController
+    publishTodayOutfitController,
+    deletePublishedOutfitController
 } from '../modules/community/community.controller.js';
 import { authenticateJWT } from '../middlewares/auth.middleware.js';
 
@@ -18,5 +19,8 @@ router.get('/today-outfit-status', authenticateJWT, getTodayOutfitStatusControll
 
 // 오늘의 아웃핏을 바로 커뮤니티에 공개
 router.patch('/publish-today-outfit', authenticateJWT, publishTodayOutfitController);
+
+// DELETE /community/outfits/:outfitId
+router.delete('/outfits/:outfitId', authenticateJWT, deletePublishedOutfitController);
 
 export default router;


### PR DESCRIPTION
close #81 
- 본인이 올린 게시글인지 확인 후 삭제
- 삭제 과정에서 연관데이터 (아웃핏에 달린 좋아요, 아웃핏에 달린 태그, 아웃핏에 달린 아이템)도 삭제 
- error.middleware에서 문자로 인식하는 문제 있어서 숫자로 변환해주는 코드 추가
